### PR TITLE
[FEAT] 메인뷰 UI 구현

### DIFF
--- a/Pision/Pision/Source/Feature/Main/MainView.swift
+++ b/Pision/Pision/Source/Feature/Main/MainView.swift
@@ -8,8 +8,60 @@
 import SwiftUI
 
 struct MainView: View {
+}
+
+extension MainView {
   var body: some View {
-    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    ZStack(alignment: .topLeading) {
+      Color.clear.ignoresSafeArea()
+      VStack {
+        Text("당신의 집중을 분석해 보세요")
+          .font(.title)
+        
+        Spacer()
+        
+        VStack {
+          Button {
+          } label: {
+            Text("시작")
+              .foregroundStyle(.white)
+              .frame(width: 150, height: 150)
+              .background(.black)
+              .clipShape(.circle)
+          }
+          .buttonStyle(.plain)
+          
+          bottomButtonView
+        }
+        Spacer()
+      }
+    }.padding(.horizontal, 16)
+  }
+  
+  private var bottomButtonView: some View {
+    HStack {
+      Button {
+      } label: {
+        Text("기록")
+          .foregroundStyle(.white)
+          .frame(width: 100, height: 100)
+          .background(.black)
+          .clipShape(.circle)
+      }
+      .buttonStyle(.plain)
+      
+      Spacer()
+      
+      Button {
+      } label: {
+        Text("설정")
+          .foregroundStyle(.white)
+          .frame(width: 100, height: 100)
+          .background(.black)
+          .clipShape(.circle)
+      }
+      .buttonStyle(.plain)
+    }
   }
 }
 


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
Lo-fi 기반으로 MVP MainView UI 구현했습니다. 네비게이션은 내일 View 전부 다 통합해서 한번에 합시다

## 📸 Screenshot
<img width="359" height="689" alt="스크린샷 2025-07-14 오후 8 49 03" src="https://github.com/user-attachments/assets/85ae279d-1039-43dc-9e97-4cb023a2fa6b" />

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->

## 🗑️ Resolved
<!-- 연결 할 이슈를 입력해주세요. ex) #1 -->
#3 