### PR TITLE
[FEAT] 자동 밝기 조절 기능 구현

### DIFF
--- a/Pision/Pision/Source/Feature/Measure/View/MeasureSheetView.swift
+++ b/Pision/Pision/Source/Feature/Measure/View/MeasureSheetView.swift
@@ -9,14 +9,14 @@ import SwiftUI
 
 // MARK: - Var
 struct MeasureSheetView: View {
-  // MARK: - ViewModel
+  // ViewModel
   @ObservedObject private var viewModel: MeasureViewModel
   
-  // MARK: - General Var
+  // General Var
   @Environment(\.dismiss) private var dismiss
   @State private var isTimerButtonState: Bool = false
   
-  // MARK: - init
+  // init
   init(viewModel: MeasureViewModel) {
     _viewModel = ObservedObject(wrappedValue: viewModel)
   }

--- a/Pision/Pision/Source/Feature/Measure/View/MeasureSheetView.swift
+++ b/Pision/Pision/Source/Feature/Measure/View/MeasureSheetView.swift
@@ -46,9 +46,9 @@ extension MeasureSheetView {
   private var infoView: some View {
     HStack(spacing: 63) {
       Button {
-        togleButtonAction()
+        toggleButtonAction()
       } label: {
-        Image(systemName: togleButtonImage())
+        Image(systemName: toggleButtonImage())
           .foregroundStyle(.black)
           .frame(width: 44, height: 44)
           .background(.gray)
@@ -77,7 +77,7 @@ extension MeasureSheetView {
 
 // MARK: - Func
 extension MeasureSheetView {
-  private func togleButtonImage() -> String {
+  private func toggleButtonImage() -> String {
     switch viewModel.timerState {
     case .stopped:
       return "play.fill"
@@ -88,7 +88,7 @@ extension MeasureSheetView {
     }
   }
   
-  private func togleButtonAction() {
+  private func toggleButtonAction() {
     switch viewModel.timerState {
     case .stopped:
       break

--- a/Pision/Pision/Source/Feature/Measure/View/MeasureToggleButtonView.swift
+++ b/Pision/Pision/Source/Feature/Measure/View/MeasureToggleButtonView.swift
@@ -1,0 +1,73 @@
+//
+//  MeasureToggleButtonView.swift
+//  Pision
+//
+//  Created by 여성일 on 7/20/25.
+//
+
+import SwiftUI
+
+// MARK: - Var
+struct MeasureToggleButtonView: View {
+  @ObservedObject private var viewModel: MeasureViewModel
+  
+  @State private var isOn: Bool = false
+  
+  let buttonWidth: CGFloat
+  let height: CGFloat
+  
+  init(
+    viewModel: MeasureViewModel,
+    buttonWidth: CGFloat,
+    height: CGFloat
+  ) {
+    _viewModel = ObservedObject(wrappedValue: viewModel)
+    self.buttonWidth = buttonWidth
+    self.height = height
+  }
+}
+
+// MARK: - View
+extension MeasureToggleButtonView {
+  var body: some View {
+    ZStack(alignment: .leading) {
+      Capsule()
+        .fill(.black.opacity(0.4))
+        .frame(width: buttonWidth * 2, height: height)
+      
+      Capsule()
+        .fill(.white)
+        .frame(width: buttonWidth, height: height)
+        .offset(x: viewModel.isAutoBrightnessModeOn ? buttonWidth : 0)
+        .animation(.easeInOut(duration: 0.25), value: isOn)
+      
+      HStack(spacing: 0) {
+        Button {
+          withAnimation {
+            viewModel.isAutoBrightnessModeOn.toggle()
+          }
+        } label: {
+          Text("자동꺼짐")
+            .font(.system(size: 12))
+            .fontWeight(.bold)
+            .foregroundStyle(!viewModel.isAutoBrightnessModeOn ? .black : .white)
+            .frame(width: buttonWidth, height: height)
+        }
+        
+        Button {
+          withAnimation {
+            viewModel.isAutoBrightnessModeOn.toggle()
+          }
+        } label: {
+          Text("계속보기")
+            .font(.system(size: 12))
+            .fontWeight(.bold)
+            .foregroundStyle(viewModel.isAutoBrightnessModeOn ? .black : .white)
+            .frame(width: buttonWidth, height: height)
+        }
+      }
+    }
+    .clipShape(Capsule())
+    .padding(.horizontal, 16)
+  }
+}

--- a/Pision/Pision/Source/Feature/Measure/View/MeasureView.swift
+++ b/Pision/Pision/Source/Feature/Measure/View/MeasureView.swift
@@ -11,14 +11,14 @@ import SwiftUI
 
 // MARK: - Var
 struct MeasureView: View {
-  // MARK: - ViewModel
+  // ViewModel
   @StateObject private var viewModel: MeasureViewModel
   
-  // MARK: - General Var
+  // General Var
   @State private var isSheetPresented: Bool = false
   @State private var isBottomButtonPresented: Bool = true
   
-  // MARK: - init
+  // init
   init(viewModel: MeasureViewModel) {
     _viewModel = StateObject(wrappedValue: viewModel)
   }
@@ -34,6 +34,12 @@ extension MeasureView {
         .ignoresSafeArea()
       
       VStack {
+        MeasureToggleButtonView(
+          viewModel: viewModel,
+          buttonWidth: 63,
+          height: 38
+        )
+        
         Spacer()
         MeasureBottomView
       }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
✅ 일단 피그마에 나와있는 커스텀 토글버튼 구현했습니다.
<img width="213" height="95" alt="스크린샷 2025-07-20 오후 9 08 28" src="https://github.com/user-attachments/assets/2194acb7-c65d-4c01-86bc-930f7ee7dac5" />

✅ 자동꺼짐은 5초 뒤 밝기 최소화, 계속보기는 5초 지나도 안변해요 ~ 

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
https://github.com/user-attachments/assets/62ea699b-09f0-4676-95c4-6e116866f556

엥 지금 봤는데 밝기는 녹화 안됨 ㅋㅋㅋㅋㅋ
## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
💡 didSet 잘 쓰면 유용해요 ~~
```swift 
@Published var isAutoBrightnessModeOn: Bool = false {
  didSet {
    if !isAutoBrightnessModeOn {
      startAutoBrightnessMode()
    } else {
      cancelAutoBrightnessMode()
      restoreBrightness()
    }
  }
}
```
didSet은 Swift에서 속성 값이 변경된 직후 실행되는 코드블럭인데, 지금 연산프로퍼티에 didSet을 쓴 이유는, isAutoBrightnessModeOn 값이 변경되었을 때 특정 동작(타이머/밝기)를 자동으로 트리거하기 위해 사용합니다 ~
➡️ View에서 viewModel.isAutoBrightnessModeOn = false만 해도 자동으로 startAutoBrightnessMode() 메소드가 호출됩니다 ~ 즉, View는 로직을 몰라도 됨. 상태만 바꾸면 자동으로 처리해줌 ~

❓ 만약 didSet안썼으면? 
```swift
@Published var isAutoBrightnessModeOn: Bool = false

func updateAutoBrightnessMode(to newValue: Bool) {
  isAutoBrightnessModeOn = newValue

  if newValue {
    startAutoDim()
  } else {
    cancelAutoDim()
    restoreBrightness()
  }
}
```
View에서 반드시 따로 updateAutoBrightnessMode를 호출해야함 !!

## 🗑️ Resolved
<!-- 연결 할 이슈를 입력해주세요. ex) #1 -->
#14 
