### PR TITLE
feat_historyView 어느정도 따라하기, 커스텀 탭바 구현(히스토리뷰 폴더 안에 있음)

### DIFF
--- a/Pision/Pision.xcodeproj/project.pbxproj
+++ b/Pision/Pision.xcodeproj/project.pbxproj
@@ -252,9 +252,11 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_IDENTITY = "Apple Development";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				CODE_SIGN_STYLE = Manual;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = "";
+				"DEVELOPMENT_TEAM[sdk=iphoneos*]" = X67DB976UU;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_NSCameraUsageDescription = "집중도 분석 기능을 사용하려면 카메라 접근 권한이 필요합니다.";
@@ -271,6 +273,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = ada.Pision;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				"PROVISIONING_PROFILE_SPECIFIER[sdk=iphoneos*]" = Pision_provisioning;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/Pision/Pision/Source/Feature/History/CustomSegmentControlView.swift
+++ b/Pision/Pision/Source/Feature/History/CustomSegmentControlView.swift
@@ -1,0 +1,29 @@
+//
+//  CustomSegmentControlView.swift
+//  Pision
+//
+//  Created by YONGWON SEO on 7/21/25.
+//
+
+import SwiftUI
+
+// MARK: - Var
+struct CustomSegmentControlView: View {
+  
+}
+
+// MARK: - View
+extension CustomSegmentControlView{
+  var body: some View {
+    Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+  }
+}
+
+// MARK: - Func
+extension CustomSegmentControlView{
+  
+}
+
+#Preview {
+    CustomSegmentControlView()
+}

--- a/Pision/Pision/Source/Feature/History/CustomTabBar/MainTabView.swift
+++ b/Pision/Pision/Source/Feature/History/CustomTabBar/MainTabView.swift
@@ -1,0 +1,170 @@
+//
+//  MainTabView.swift
+//  Pision
+//
+//  Created by YONGWON SEO on 7/21/25.
+//
+
+import SwiftUI
+
+enum Tab {
+    case home
+    case measure
+    case record
+}
+
+struct MainTabView: View {
+    @State private var selectedTab: Tab = .home
+  
+  var cameraOff:Bool {
+    selectedTab != .measure
+  }
+
+    var body: some View {
+        ZStack(alignment: .bottom) {
+            Group {
+                switch selectedTab {
+                case .home:
+                    Color.white.overlay(Text("홈").font(.largeTitle))
+                case .measure:
+                    MeasureView()
+                case .record:
+                    HistoryView()
+                }
+            }
+            .ignoresSafeArea()
+          
+          if cameraOff {
+              CustomTabBar(selectedTab: $selectedTab)
+          }
+        }
+        .ignoresSafeArea(edges: .bottom)
+    }
+}
+
+struct CustomTabBar: View {
+    @Binding var selectedTab: Tab
+
+    var body: some View {
+        ZStack {
+            // 배경 모양 (곡선)
+            CustomTabBarShape()
+                .fill(Color.white)
+                .frame(height: 90)
+                .shadow(color: .black.opacity(0.1), radius: 6, x: 0, y: -2)
+
+            // 왼쪽/오른쪽 탭 버튼
+            HStack {
+                tabItem(icon: "house.fill", label: "홈", tab: .home)
+                Spacer()
+                tabItem(icon: "doc.text.fill", label: "기록", tab: .record)
+            }
+            .padding(.horizontal, 48)
+            .padding(.bottom, 16)
+
+            // 중앙 버튼
+            Button(action: {
+                selectedTab = .measure
+            }) {
+                ZStack {
+                    Circle()
+                        .fill(Color.blue)
+                        .frame(width: 64, height: 64)
+                        .shadow(radius: 4)
+                    Image(systemName: "clock.badge.checkmark")
+                        .foregroundColor(.white)
+                        .font(.system(size: 28))
+                  // 중앙 버튼 텍스트
+                  Text("측정 시작")
+                    .font(.system(size:7))
+                      .foregroundColor(.white)
+                      .offset(y: 22)
+                }
+            }
+            .offset(y: -32)
+
+        }
+    }
+
+    func tabItem(icon: String, label: String, tab: Tab) -> some View {
+        Button {
+            selectedTab = tab
+        } label: {
+            VStack(spacing: 4) {
+                Image(systemName: icon)
+                    .font(.system(size: 20))
+                    .foregroundColor(selectedTab == tab ? .blue : .gray)
+
+                Text(label)
+                    .font(.caption)
+                    .foregroundColor(selectedTab == tab ? .blue : .gray)
+            }
+        }
+    }
+}
+
+struct CustomTabBarShape: Shape {
+    func path(in rect: CGRect) -> Path {
+        let width = rect.width
+        let height = rect.height
+
+        // 중앙과 반지름 설정
+        let centerX = width / 2
+        let buttonRadius: CGFloat = 35
+        let sideRadius: CGFloat = 28
+
+        // 좌우 곡선의 수직 중심선과 y좌표
+        let curveY: CGFloat = 0
+        let sideCenterY = curveY + sideRadius
+        let buttonCenterY = curveY + buttonRadius
+
+        var path = Path()
+        path.move(to: CGPoint(x: 0, y: curveY))
+
+        // 왼쪽 직선
+        path.addLine(to: CGPoint(x: centerX - buttonRadius - sideRadius, y: curveY))
+
+        // 왼쪽 90도 아크 (↘)
+        path.addArc(
+            center: CGPoint(x: centerX - buttonRadius - 30, y: sideCenterY),
+            radius: sideRadius,
+            startAngle: .degrees(180),
+            endAngle: .degrees(70),
+            clockwise: false
+        )
+
+        // 중앙 반원 (◯)
+        path.addArc(
+            center: CGPoint(x: centerX, y: buttonCenterY - 20),
+            radius: buttonRadius + 4,
+            startAngle: .degrees(160),
+            endAngle: .degrees(20),
+            clockwise: true
+        )
+
+        // 오른쪽 90도 아크 (↗)
+        path.addArc(
+            center: CGPoint(x: centerX + buttonRadius + 30, y: sideCenterY),
+            radius: sideRadius,
+            startAngle: .degrees(160),
+            endAngle: .degrees(270),
+            clockwise: false
+        )
+
+        // 오른쪽 직선
+        path.addLine(to: CGPoint(x: width, y: 0))
+      
+        // 화면 오른쪽 아래 끝
+        path.addLine(to: CGPoint(x: width, y: height))
+        // 화면 왼쪽 아래 끝
+        path.addLine(to: CGPoint(x: 0, y: height))
+        // 화면 왼쪽 아래 끝이랑 시작점 연결해줌
+        path.closeSubpath()
+
+        return path
+    }
+}
+
+#Preview {
+    MainTabView()
+}

--- a/Pision/Pision/Source/Feature/History/FixedOverListView.swift
+++ b/Pision/Pision/Source/Feature/History/FixedOverListView.swift
@@ -1,0 +1,79 @@
+//
+//  fixedOverListView.swift
+//  Pision
+//
+//  Created by YONGWON SEO on 7/21/25.
+//
+
+import SwiftUI
+
+// MARK: - Var
+struct FixedOverListView: View {
+  @State private var selectedIndex: String = "주"
+  let options = ["주", "월", "년", "전체"]
+}
+
+// MARK: - View
+extension FixedOverListView {
+  
+  var body: some View {
+    VStack{
+      
+      
+      
+      Picker("기간 선택", selection: $selectedIndex){
+        ForEach(options, id:\.self){ option in
+          Text((option))
+        }
+      }
+      .pickerStyle(.segmented)
+      .frame(maxHeight:.infinity)
+      .padding()
+      
+      VStack{
+        Text("집중시간")
+        Text("6H 40")
+      }
+      .padding()
+      .frame(maxHeight:.infinity)
+      
+      VStack{
+
+        HStack{
+          VStack{
+            Text("횟수")
+            Text("3")
+          }
+          .frame(maxWidth:.infinity)
+          VStack{
+            Text("총 공부시간")
+            Text("9H 32")
+          }
+          .frame(maxWidth:.infinity)
+          VStack{
+            Text("평균 집중도")
+            Text("97%")
+          }
+          .frame(maxWidth:.infinity)
+        }
+        .frame(maxHeight:.infinity)
+      }
+      .padding()
+
+    }
+    .background(RoundedRectangle(cornerRadius: 12).fill(Color.blue.opacity(0.1)))
+    .padding(12)
+  }
+}
+
+// MARK: - Func
+extension FixedOverListView {
+  
+
+  
+}
+
+
+#Preview {
+    FixedOverListView()
+}

--- a/Pision/Pision/Source/Feature/History/HistoryRowView.swift
+++ b/Pision/Pision/Source/Feature/History/HistoryRowView.swift
@@ -1,0 +1,42 @@
+//
+//  HistoryRowView.swift
+//  Pision
+//
+//  Created by YONGWON SEO on 7/21/25.
+//
+
+import SwiftUI
+
+// MARK: - Var
+struct HistoryRowView: View {
+
+}
+
+// MARK: - View
+extension HistoryRowView {
+  var body: some View {
+    HStack{
+      VStack(alignment: .leading){
+        Text("2025.03.05")
+        Text("6h 40")
+        Text("7h 22")
+      }
+      .frame(maxWidth:.infinity, maxHeight: .infinity, alignment:.leading)
+      Spacer()
+      Text("도형")
+    }
+    .padding()
+    .background(RoundedRectangle(cornerRadius: 12).fill(Color.blue.opacity(0.2)))
+    .padding(.vertical, 4)
+    .padding(.horizontal, 12)
+  }
+}
+
+// MARK: - Func
+extension HistoryRowView{
+  
+}
+
+#Preview {
+    HistoryRowView()
+}

--- a/Pision/Pision/Source/Feature/History/HistoryView.swift
+++ b/Pision/Pision/Source/Feature/History/HistoryView.swift
@@ -1,0 +1,56 @@
+//
+//  HistoryView.swift
+//  Pision
+//
+//  Created by YONGWON SEO on 7/21/25.
+//
+
+import SwiftUI
+
+// MARK: - Var
+struct HistoryView: View {
+  
+}
+
+// MARK: - View
+extension HistoryView {
+  var body: some View {
+    VStack{
+      HStack{
+        HStack{
+          Text("이미지")
+          Text("닉네임")
+          Spacer()
+          Image(systemName: "gearshape")
+        }.padding(12)
+      }
+      VStack{
+        FixedOverListView()
+      }
+      VStack {
+        ScrollView {
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+          HistoryRowView()
+        }.frame(maxHeight: .infinity)
+      }
+    }
+  }
+}
+
+// MARK: - Func
+extension HistoryView {
+  
+}
+
+#Preview {
+    HistoryView()
+}


### PR DESCRIPTION
## 🔍 PR Content
아직 히스토리뷰 하이파이가 안나와서 미드파이 따라하기 정도 진행했고,
커스텀 탭바 만드는 테스크 받고 진행한 뒤 PR드립니다. 
하드코딩 되어있는 부분이 있긴 한데, 일단 진행합니다.
테스트할때에는 앱 시작점에서 MainTabView로 가서 했습니다 음음
지금 이 커밋부분에는 그거 없으니까 ㄱㅊ합니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
![KakaoTalk_Photo_2025-07-22-01-35-29 001](https://github.com/user-attachments/assets/106897a5-160e-4ae9-b115-25f377ab915a)
![KakaoTalk_Photo_2025-07-22-01-35-29 002](https://github.com/user-attachments/assets/15a7b839-c775-408f-b59a-cc15f07e4afa)
![KakaoTalk_Photo_2025-07-22-01-35-29 003](https://github.com/user-attachments/assets/7f6281a0-42a1-466e-af71-74fe225bbabc)


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->

## 🗑️ Resolved
<!-- 연결 할 이슈를 입력해주세요. ex) #1 -->
