### PR TITLE
[FEAT] 데이터 처리해서 SwiftData에 저장하는 기능 구현 + 부가기능 추가 구현

### DIFF
--- a/Pision/Pision/Source/App/PisionApp.swift
+++ b/Pision/Pision/Source/App/PisionApp.swift
@@ -5,13 +5,31 @@
 //  Created by 여성일 on 7/14/25.
 //
 
+import SwiftData
 import SwiftUI
 
 @main
 struct PisionApp: App {
+  var modelContainer: ModelContainer = {
+    let schema = Schema([
+      TaskData.self,
+      AvgCoreScore.self,
+      AvgAuxScore.self
+    ])
+    
+    let configuration = ModelConfiguration(schema: schema, isStoredInMemoryOnly: false)
+    
+    do {
+      return try ModelContainer(for: schema, configurations: [configuration])
+    } catch {
+      fatalError("ModelContainer err")
+    }
+  }()
+  
   var body: some Scene {
     WindowGroup {
       MeasureView()
     }
+    .modelContainer(modelContainer)
   }
 }

--- a/Pision/Pision/Source/Core/Data/Enum/Enum + SaveResult.swift
+++ b/Pision/Pision/Source/Core/Data/Enum/Enum + SaveResult.swift
@@ -1,0 +1,12 @@
+//
+//  Enum.swift
+//  Pision
+//
+//  Created by 여성일 on 7/24/25.
+//
+
+enum SaveResult {
+  case success
+  case failed
+  case skippedLessThan10Minutes
+}

--- a/Pision/Pision/Source/Core/Data/Model/AuxScoreModel.swift
+++ b/Pision/Pision/Source/Core/Data/Model/AuxScoreModel.swift
@@ -7,9 +7,9 @@
 
 import Foundation
 
-struct AuxScore {
+struct AuxScoreModel {
   let blinkScore: Float
   let yawStabilityScore: Float
   let mlSnoozeScore: Float
-  let AuxScore: Float
+  let auxScore: Float
 }

--- a/Pision/Pision/Source/Core/Data/Model/AvgAuxScoreModel.swift
+++ b/Pision/Pision/Source/Core/Data/Model/AvgAuxScoreModel.swift
@@ -1,0 +1,15 @@
+//
+//  AvgAuxScoreModel.swift
+//  Pision
+//
+//  Created by 여성일 on 7/23/25.
+//
+
+import Foundation
+
+struct AvgAuxScoreModel {
+  let avgBlinkScore: Float
+  let avgYawStabilityScore: Float
+  let avgMlSnoozeScore: Float
+  let avgAuxScore: Float
+}

--- a/Pision/Pision/Source/Core/Data/Model/AvgCoreScoreModel.swift
+++ b/Pision/Pision/Source/Core/Data/Model/AvgCoreScoreModel.swift
@@ -1,0 +1,16 @@
+//
+//  AvgCoreScoreModel.swift
+//  Pision
+//
+//  Created by 여성일 on 7/23/25.
+//
+
+import Foundation
+
+struct AvgCoreScoreModel {
+  let avgYawScore: Float
+  let avgEyeOpenScore: Float
+  let avgEyeClosedScore: Float
+  let avgBlinkFrequency: Float
+  let avgCoreScore: Float
+}

--- a/Pision/Pision/Source/Core/Data/Model/CoreScoreModel.swift
+++ b/Pision/Pision/Source/Core/Data/Model/CoreScoreModel.swift
@@ -7,7 +7,7 @@
 
 import Foundation
 
-struct CoreScore {
+struct CoreScoreModel {
   let yawScore: Float
   let eyeOpenScore: Float
   let eyeClosedScore: Float

--- a/Pision/Pision/Source/Core/Data/Model/TaskDataModel.swift
+++ b/Pision/Pision/Source/Core/Data/Model/TaskDataModel.swift
@@ -1,0 +1,20 @@
+//
+//  TaskDataModel.swift
+//  Pision
+//
+//  Created by 여성일 on 7/23/25.
+//
+
+import Foundation
+
+struct TaskDataModel {
+  let startTime: Date
+  let endTime: Date
+  let averageScore: Float
+  let focusRatio: [Float]
+  let focusTime: Int
+  let durationTime: Int
+  let avgCoreDatas: [AvgCoreScoreModel]
+  let avgAuxDatas: [AvgAuxScoreModel]
+}
+

--- a/Pision/Pision/Source/Core/Data/SwiftDataModel/AvgAuxScore.swift
+++ b/Pision/Pision/Source/Core/Data/SwiftDataModel/AvgAuxScore.swift
@@ -1,0 +1,28 @@
+//
+//  AuxScore.swift
+//  Pision
+//
+//  Created by 여성일 on 7/23/25.
+
+
+import SwiftData
+
+@Model
+class AvgAuxScore {
+  var avgBlinkScore: Float
+  var avgYawStabilityScore: Float
+  var avgMlSnoozeScore: Float
+  var avgAuxScore: Float
+  
+  init(
+    avgBlinkScore: Float,
+    avgYawStabilityScore: Float,
+    avgMlSnoozeScore: Float,
+    avgAuxScore: Float
+  ) {
+    self.avgBlinkScore = avgBlinkScore
+    self.avgYawStabilityScore = avgYawStabilityScore
+    self.avgMlSnoozeScore = avgMlSnoozeScore
+    self.avgAuxScore = avgAuxScore
+  }
+}

--- a/Pision/Pision/Source/Core/Data/SwiftDataModel/AvgCoreScore.swift
+++ b/Pision/Pision/Source/Core/Data/SwiftDataModel/AvgCoreScore.swift
@@ -1,0 +1,31 @@
+//
+//  AvgCoreScore.swift
+//  Pision
+//
+//  Created by 여성일 on 7/23/25.
+//
+
+import SwiftData
+
+@Model
+class AvgCoreScore {
+  var avgYawScore: Float
+  var avgEyeOpenScore: Float
+  var avgEyeClosedScore: Float
+  var avgBlinkFrequency: Float
+  var avgCoreScore: Float
+  
+  init(
+    avgYawScore: Float,
+    avgEyeOpenScore: Float,
+    avgEyeClosedScore: Float,
+    avgBlinkFrequency: Float,
+    avgCoreScore: Float
+  ) {
+    self.avgYawScore = avgYawScore
+    self.avgEyeOpenScore = avgEyeOpenScore
+    self.avgEyeClosedScore = avgEyeClosedScore
+    self.avgBlinkFrequency = avgBlinkFrequency
+    self.avgCoreScore = avgCoreScore
+  }
+}

--- a/Pision/Pision/Source/Core/Data/SwiftDataModel/TaskData.swift
+++ b/Pision/Pision/Source/Core/Data/SwiftDataModel/TaskData.swift
@@ -1,0 +1,43 @@
+//
+//  TaskData.swift
+//  Pision
+//
+//  Created by 여성일 on 7/23/25.
+//
+
+import Foundation
+import SwiftData
+
+@Model
+class TaskData {
+  @Attribute(.unique) var id: UUID = UUID()
+  var startTime: Date
+  var endTime: Date
+  var averageScore: Float
+  var focusRatio: [Float]
+  var focusTime: Int
+  var durationTime: Int
+  
+  @Relationship(deleteRule: .cascade) var avgCoreDatas: [AvgCoreScore]
+  @Relationship(deleteRule: .cascade) var avgAuxDatas: [AvgAuxScore]
+  
+  init(
+    startTime: Date,
+    endTime: Date,
+    averageScore: Float,
+    focusRatio: [Float],
+    focusTime: Int,
+    durationTime: Int,
+    avgCoreDatas: [AvgCoreScore],
+    avgAuxDatas: [AvgAuxScore]
+  ) {
+    self.startTime = startTime
+    self.endTime = endTime
+    self.averageScore = averageScore
+    self.focusRatio = focusRatio
+    self.focusTime = focusTime
+    self.durationTime = durationTime
+    self.avgCoreDatas = avgCoreDatas
+    self.avgAuxDatas = avgAuxDatas
+  }
+}

--- a/Pision/Pision/Source/Feature/Measure/View/MeasureSheetView.swift
+++ b/Pision/Pision/Source/Feature/Measure/View/MeasureSheetView.swift
@@ -5,6 +5,7 @@
 //  Created by 여성일 on 7/20/25.
 //
 
+import SwiftData
 import SwiftUI
 
 // MARK: - Var
@@ -12,14 +13,16 @@ struct MeasureSheetView: View {
   // ViewModel
   @ObservedObject private var viewModel: MeasureViewModel
   
-  // General Var
-  @State private var isTimerButtonState: Bool = false
-  
+  // SwiftData
+  private let context: ModelContext
+
   // init
   init(
-    viewModel: MeasureViewModel
+    viewModel: MeasureViewModel,
+    context: ModelContext
   ) {
     self.viewModel = viewModel
+    self.context = context
   }
 }
 
@@ -64,7 +67,16 @@ extension MeasureSheetView {
         .font(.title)
       
       Button {
-        viewModel.timerStop()
+        viewModel.timerStop(context: context) { result in
+          switch result {
+          case .success:
+            print("성공")
+          case .failed:
+            print("실패")
+          case .skippedLessThan10Minutes:
+            print("10분 미만")
+          }
+        }
       } label: {
         Image(systemName: "stop.fill")
           .foregroundStyle(.white)
@@ -102,6 +114,6 @@ extension MeasureSheetView {
   }
 }
 
-#Preview {
-  MeasureSheetView(viewModel: MeasureViewModel())
-}
+//#Preview {
+//  MeasureSheetView(viewModel: MeasureViewModel())
+//}

--- a/Pision/Pision/Source/Feature/Measure/View/MeasureSheetView.swift
+++ b/Pision/Pision/Source/Feature/Measure/View/MeasureSheetView.swift
@@ -37,7 +37,7 @@ extension MeasureSheetView {
         
         infoView
         
-        Text("80%")
+        Text("\(viewModel.currentFocusRatio)")
           .foregroundStyle(.white)
           .frame(width: 109, height: 40)
           .background(.gray)

--- a/Pision/Pision/Source/Feature/Measure/View/MeasureView.swift
+++ b/Pision/Pision/Source/Feature/Measure/View/MeasureView.swift
@@ -7,12 +7,16 @@
 
 import AVFoundation
 import CoreML
+import SwiftData
 import SwiftUI
 
 // MARK: - Var
 struct MeasureView: View {
   // ViewModel
   @StateObject private var viewModel: MeasureViewModel
+  
+  // SwiftData
+  @Environment(\.modelContext) private var context
   
   // General Var
   @State private var isSheetPresented: Bool = false
@@ -59,16 +63,32 @@ extension MeasureView {
           }
           .buttonStyle(.plain)
           
-          MeasureSheetView(viewModel: viewModel)
-            .frame(maxWidth: .infinity, maxHeight: 196)
+          MeasureSheetView(
+            viewModel: viewModel,
+            context: context
+          )
+          .frame(maxWidth: .infinity, maxHeight: 196)
         }
       }
     }
     .onAppear {
       viewModel.cameraStart()
+      viewModel.debugPrintAllSavedData(context: context)
     }
     .onDisappear {
       viewModel.cameraStop()
+    }
+    .onReceive(viewModel.$shouldDimScreen) { shouldDim in
+      if shouldDim {
+        dimScreenGradually(to: 0.01, duration: 0.3)
+      } else {
+        UIScreen.main.brightness = 1.0
+      }
+    }
+    .onTapGesture {
+      guard !viewModel.isAutoBrightnessModeOn else { return }
+      UIScreen.main.brightness = 1.0
+      viewModel.resetAutoDimTimer()
     }
   }
 }
@@ -81,6 +101,20 @@ extension MeasureView {
   
   private func updateBottomButtonVisibility() {
     isBottomButtonPresented = false
+  }
+  
+  private func dimScreenGradually(to target: CGFloat, duration: TimeInterval) {
+    let current = UIScreen.main.brightness
+    let steps = 60
+    let interval = duration / Double(steps)
+    let delta = (current - target) / CGFloat(steps)
+    
+    for step in 1...steps {
+      DispatchQueue.main.asyncAfter(deadline: .now() + interval * Double(step)) {
+        let newBrightness = max(target, current - delta * CGFloat(step))
+        UIScreen.main.brightness = newBrightness
+      }
+    }
   }
 }
 

--- a/Pision/Pision/Source/Utilities/Extension/Extension + CGPoint.swift
+++ b/Pision/Pision/Source/Utilities/Extension/Extension + CGPoint.swift
@@ -8,6 +8,10 @@
 import Foundation
 
 extension CGPoint {
+  /// 두 점 사이의 유클리드 거리(눈 사이 거리 등)를 계산합니다.
+  /// `self`는 기준 좌표이며, `other`는 비교 대상 좌표입니다.
+  /// - Parameter other: 비교할 다른 CGPoint 좌표
+  /// - Returns: 두 점 사이의 거리 (`CGFloat`)
   func eyeDistance(to other: CGPoint) -> CGFloat {
     hypot(self.x - other.x, self.y - other.y)
   }

--- a/Pision/Pision/Source/Utilities/Extension/Extension + Float.swift
+++ b/Pision/Pision/Source/Utilities/Extension/Extension + Float.swift
@@ -8,6 +8,8 @@
 import Foundation
 
 extension Array where Element == Float {
+  /// Float 배열의 평균을 계산합니다.
+  /// 배열이 비어 있으면 0을 반환합니다.
   func average() -> Float {
     guard !isEmpty else { return 0 }
     return self.reduce(0, +) / Float(self.count)

--- a/Pision/Pision/Source/Utilities/Extension/Extension + Int.swift
+++ b/Pision/Pision/Source/Utilities/Extension/Extension + Int.swift
@@ -1,0 +1,20 @@
+//
+//  Extension + Int.swift
+//  Pision
+//
+//  Created by 여성일 on 7/23/25.
+//
+
+import Foundation
+
+extension Int {
+  /// 정수(Int)를 `Float` 타입으로 변환합니다.
+  ///
+  /// `Float(값)`을 직접 사용하는 대신, 간결하게 타입 변환을 할 수 있습니다.
+  ///
+  /// ```
+  /// let intValue = 5
+  /// let floatValue = intValue.f  // 5.0
+  /// ```
+  var f: Float { Float(self) }
+}

--- a/Pision/Pision/Source/Utilities/Manager/CameraManager.swift
+++ b/Pision/Pision/Source/Utilities/Manager/CameraManager.swift
@@ -7,6 +7,7 @@
 
 import AVFoundation
 
+// MARK: - CameraManager
 final class CameraManager: NSObject {
   let session = AVCaptureSession()
   
@@ -21,7 +22,12 @@ final class CameraManager: NSObject {
     self.visionManager = visionManager
     super.init()
   }
-  
+}
+
+// MARK: - General Func
+extension CameraManager {
+  /// 캡처 세션을 시작합니다.
+  /// `sessionQueue`에서 비동기적으로 실행되며, 이미 실행 중인 경우는 무시합니다.
   func startSession() {
     sessionQueue.async {
       if !self.session.isRunning {
@@ -30,6 +36,8 @@ final class CameraManager: NSObject {
     }
   }
   
+  /// 캡처 세션을 중지합니다.
+  /// `sessionQueue`에서 비동기적으로 실행되며, 실행 중이 아닐 경우는 무시합니다.
   func stopSession() {
     sessionQueue.async {
       if self.session.isRunning {
@@ -38,14 +46,21 @@ final class CameraManager: NSObject {
     }
   }
   
+  /// 측정을 시작합니다.
+  /// 내부 상태 변수 `isMeasuring`을 `true`로 설정합니다.
   func startMeasuring() {
     isMeasuring = true
   }
   
+  /// 측정을 중단합니다.
+  /// 내부 상태 변수 `isMeasuring`을 `false`로 설정합니다.
   func stopMeasuring() {
     isMeasuring = false
   }
   
+  
+  /// 카메라 권한을 요청하고, 허용된 경우 세션 구성을 진행합니다.
+  /// 이미 권한이 있는 경우 바로 구성하며, 거부된 경우 로그만 출력합니다.
   func requestAndCheckPermissions() {
     switch AVCaptureDevice.authorizationStatus(for: .video) {
     case .notDetermined:
@@ -65,13 +80,20 @@ final class CameraManager: NSObject {
       print("알 수 없는 권한 상태")
     }
   }
-  
+}
+
+// MARK: - Private Func
+extension CameraManager {
+  /// 세션이 아직 구성되지 않은 경우 한 번만 세션을 구성합니다.
+  /// `isSessionConfigured` 플래그를 이용해 중복 구성을 방지합니다.
   private func configureSessionIfNeeded() {
     guard !isSessionConfigured else { return }
     isSessionConfigured = true
     configureSession()
   }
   
+  /// 캡처 세션을 구성합니다.
+  /// 프론트 카메라를 입력으로 설정하고, 비디오 출력 설정 및 델리게이트를 등록합니다.
   private func configureSession() {
     session.beginConfiguration()
     session.sessionPreset = .high
@@ -105,6 +127,7 @@ final class CameraManager: NSObject {
   }
 }
 
+// MARK: - Delegate
 extension CameraManager: AVCaptureVideoDataOutputSampleBufferDelegate {
   func captureOutput(_ output: AVCaptureOutput, didOutput sampleBuffer: CMSampleBuffer, from connection: AVCaptureConnection) {
     guard isMeasuring else { return }
@@ -113,3 +136,5 @@ extension CameraManager: AVCaptureVideoDataOutputSampleBufferDelegate {
     visionManager.processBodyPose(pixelBuffer: pixelBuffer)
   }
 }
+
+

--- a/Pision/Pision/Source/Utilities/Manager/MLManager.swift
+++ b/Pision/Pision/Source/Utilities/Manager/MLManager.swift
@@ -8,6 +8,7 @@
 import CoreML
 import Vision
 
+// MARK: - MLManager
 final class MLManager {
   private let model: pisionModel
   private var poseBuffer: [VNHumanBodyPoseObservation] = []
@@ -19,7 +20,14 @@ final class MLManager {
     }
     self.model = loaded
   }
+}
 
+// MARK: - General Func
+extension MLManager {
+  /// 사람의 자세 관측값을 입력으로 받아, 학습된 CoreML 모델을 통해 동작 라벨을 예측합니다.
+  ///
+  /// - Parameter observation: `VNHumanBodyPoseObservation` 형태의 단일 자세 프레임입니다.
+  /// - Returns: 예측된 동작 라벨 문자열. 입력이 30프레임 미만일 경우 빈 문자열을 반환합니다.
   func bodyPosePredict(from observation: VNHumanBodyPoseObservation) -> String {
     poseBuffer.append(observation)
     

--- a/Pision/Pision/Source/Utilities/Manager/ScoreManager.swift
+++ b/Pision/Pision/Source/Utilities/Manager/ScoreManager.swift
@@ -1,0 +1,124 @@
+//
+//  ScoreManager.swift
+//  Pision
+//
+//  Created by 여성일 on 7/23/25.
+//
+
+import Foundation
+
+// MARK: - ScoreManager
+final class ScoreManager {
+  /// EAR, YAW, 눈 깜빡임 데이터를 바탕으로 집중도를 나타내는 CoreScoreModel을 계산합니다.
+  /// - Parameters:
+  ///   - ears: EAR 값 배열
+  ///   - yaws: YAW 값 배열
+  ///   - blinkCount: 눈 깜빡임 횟수
+  /// - Returns: CoreScoreModel 점수 결과
+  func calculateCore(from ears: [Float], yaws: [Float], blinkCount: Int) -> CoreScoreModel {
+    let avgYaw = yaws.map { $0 >= 0.786 ? $0 : 0 }.average()
+    let yawScore = (1 - minMaxNormalize(value: avgYaw, maxValue: 0.7)) * 100 * 0.25
+
+    let avgEAR = ears.average()
+    let eyeOpenScore = minMaxNormalize(value: avgEAR, minValue: 0.1, maxValue: 0.18) * 100 * 0.3
+
+    let eyeClosedRatio = Float(ears.filter { $0 < 0.1 }.count) * 0.0405 / 30
+    let eyeClosedScore = (1 - minMaxNormalize(value: eyeClosedRatio, maxValue: 1)) * 100 * 0.2
+
+    let blinkRatio = Float(blinkCount) / 15
+    let blinkScore = max(0, (1 - blinkRatio) * 100 * 0.25)
+
+    let core = yawScore + eyeOpenScore + eyeClosedScore + blinkScore
+
+    return CoreScoreModel(
+      yawScore: yawScore,
+      eyeOpenScore: eyeOpenScore,
+      eyeClosedScore: eyeClosedScore,
+      blinkFrequency: blinkScore,
+      coreScore: core
+    )
+  }
+  
+  /// EAR, YAW, ML 예측 결과를 바탕으로 집중도를 나타내는 AuxScoreModel을 계산합니다.
+  /// - Parameters:
+  ///   - ears: EAR 값 배열
+  ///   - yaws: YAW 값 배열
+  ///   - ml: ML 예측 라벨 배열
+  ///   - blinkCount: 눈 깜빡임 횟수
+  /// - Returns: AuxScoreModel 점수 결과
+  func calculateAux(from ears: [Float], yaws: [Float], ml: [String], blinkCount: Int) -> AuxScoreModel {
+    let blinkScore = (1 - minMaxNormalize(value: Float(blinkCount), maxValue: 30)) * 100 * 0.25
+
+    let yawDiff = zip(yaws.dropFirst(), yaws).map { abs($0 - $1) }
+    let yawStability = (1 - minMaxNormalize(value: yawDiff.average(), maxValue: 0.2)) * 100 * 0.35
+
+    let count = min(ml.count, ears.count, yaws.count)
+    let snooze = (0..<count).map { i in
+      ml[i] == "snooze" || ears[i] < 0.1 || abs(yaws[i]) > 0.3
+    }
+    let snoozeRatio = snooze.filter { $0 }.count.f / snooze.count.f
+    let mlSnooze = pow(1 - snoozeRatio, 2) * 100 * 0.4
+
+    let aux = blinkScore + yawStability + mlSnooze
+    return AuxScoreModel(
+      blinkScore: blinkScore,
+      yawStabilityScore: yawStability,
+      mlSnoozeScore: mlSnooze,
+      auxScore: aux
+    )
+  }
+
+  /// CoreScore와 AuxScore를 바탕으로 TotalScore를 계산합니다.
+  /// - Parameters:
+  ///   - core: CoreScoreModel
+  ///   - aux: AuxScoreModel
+  /// - Returns: TotalScore Float 값
+  func calculateTotal(core: CoreScoreModel, aux: AuxScoreModel) -> Float {
+    return core.coreScore * 0.7 + aux.auxScore * 0.3
+  }
+
+  /// CoreScoreModel의 값들의 평균치를 계산합니다.
+  /// - Parameters:
+  ///   - scores: CoreScoreModel 배열
+  /// - Returns: AvgCoreScoreModel
+  func averageCore(from scores: [CoreScoreModel]) -> AvgCoreScoreModel {
+    AvgCoreScoreModel(
+      avgYawScore: scores.map { $0.yawScore }.average(),
+      avgEyeOpenScore: scores.map { $0.eyeOpenScore }.average(),
+      avgEyeClosedScore: scores.map { $0.eyeClosedScore }.average(),
+      avgBlinkFrequency: scores.map { $0.blinkFrequency }.average(),
+      avgCoreScore: scores.map { $0.coreScore }.average()
+    )
+  }
+  
+  /// AuxScoreModel의 값들의 평균치를 계산합니다.
+  /// - Parameters:
+  ///   - scores: AuxScoreModel 배열
+  /// - Returns: AvgAuxScoreModel
+  func averageAux(from scores: [AuxScoreModel]) -> AvgAuxScoreModel {
+    AvgAuxScoreModel(
+      avgBlinkScore: scores.map { $0.blinkScore }.average(),
+      avgYawStabilityScore: scores.map { $0.yawStabilityScore }.average(),
+      avgMlSnoozeScore: scores.map { $0.mlSnoozeScore }.average(),
+      avgAuxScore: scores.map { $0.auxScore }.average()
+    )
+  }
+}
+
+// MARK: - Private Func
+extension ScoreManager {
+  /// 정규화를 수행하여 값을 0에서 1 사이로 변환합니다.
+  ///
+  /// 주어진 값 `value`를 `minValue`와 `maxValue` 범위 내에서 Min-Max 정규화를 적용해 0에서 1 사이의 값으로 반환합니다.
+  /// 결과는 범위를 벗어나지 않도록 0~1로 클램핑됩니다.
+  ///
+  /// - Parameters:
+  ///   - value: 정규화할 원본 값.
+  ///   - minValue: 값의 최소 범위 (기본값은 0).
+  ///   - maxValue: 값의 최대 범위.
+  /// - Returns: 정규화된 0~1 사이의 `Float` 값. `minValue`와 `maxValue`가 같으면 0을 반환합니다.
+  private func minMaxNormalize(value: Float, minValue: Float = 0, maxValue: Float) -> Float {
+      guard maxValue != minValue else { return 0 }
+      return min(max((value - minValue) / (maxValue - minValue), 0), 1)
+  }
+}

--- a/Pision/Pision/Source/Utilities/Manager/SwiftDataManager.swift
+++ b/Pision/Pision/Source/Utilities/Manager/SwiftDataManager.swift
@@ -1,0 +1,112 @@
+//
+//  SwiftDataManager.swift
+//  Pision
+//
+//  Created by 여성일 on 7/24/25.
+//
+
+import SwiftData
+
+final class SwiftDataManager {
+  /// 사용자의 집중 측정 데이터를 SwiftData에 저장합니다.
+  ///
+  /// - Parameters:
+  ///   - context: SwiftData의 `ModelContext` 인스턴스입니다.
+  ///   - taskData: 저장할 사용자 측정 데이터 (`TaskDataModel` 타입)입니다.
+  ///   - completion: 저장 성공 여부를 `Bool`로 반환하는 완료 핸들러입니다.
+  func saveTaskDataToSwiftData(
+    context: ModelContext,
+    taskData: TaskDataModel,
+    completion: @escaping (Bool) -> Void
+  ) {
+    let coreModels = taskData.avgCoreDatas.map {
+      AvgCoreScore(
+        avgYawScore: $0.avgYawScore,
+        avgEyeOpenScore: $0.avgEyeOpenScore,
+        avgEyeClosedScore: $0.avgEyeClosedScore,
+        avgBlinkFrequency: $0.avgBlinkFrequency,
+        avgCoreScore: $0.avgCoreScore
+      )
+    }
+    
+    let auxModels = taskData.avgAuxDatas.map {
+      AvgAuxScore(
+        avgBlinkScore: $0.avgBlinkScore,
+        avgYawStabilityScore: $0.avgYawStabilityScore,
+        avgMlSnoozeScore: $0.avgMlSnoozeScore,
+        avgAuxScore: $0.avgAuxScore
+      )
+    }
+    
+    let taskData = TaskData(
+      startTime: taskData.startTime,
+      endTime: taskData.endTime,
+      averageScore: taskData.averageScore,
+      focusRatio: taskData.focusRatio,
+      focusTime: taskData.focusTime,
+      durationTime: taskData.durationTime,
+      avgCoreDatas: coreModels,
+      avgAuxDatas: auxModels
+    )
+    
+    context.insert(taskData)
+    
+    do {
+      try context.save()
+      print("✅ SwiftData 저장 성공")
+      completion(true)
+    } catch {
+      print("❌ SwiftData 저장 실패: \(error)")
+      completion(false)
+    }
+  }
+  
+  /// SwiftData에서 모든 TaskData를 불러와 콘솔에 출력합니다.
+  ///
+  /// - Parameter context: SwiftData의 `ModelContext` 인스턴스입니다.
+  func fetchAllTaskData(context: ModelContext) {
+    let fetchDescriptor = FetchDescriptor<TaskData>()
+    
+    do {
+      let results = try context.fetch(fetchDescriptor)
+      
+      for (i, task) in results.enumerated() {
+        print("""
+        \n====== TaskData [\(i + 1)] ======
+        startTime: \(task.startTime)
+        endTime: \(task.endTime)
+        averageScore: \(task.averageScore)
+        durationTime: \(task.durationTime)초
+        focusTime: \(task.focusTime)초
+        focusRatio: \(task.focusRatio)
+        """)
+        
+        print("avgCoreDatas \(task.avgCoreDatas.count)개")
+        for (j, core) in task.avgCoreDatas.enumerated() {
+          print("""
+          avgCoreDatas[\(j + 1)]
+          - avgYawScore: \(core.avgYawScore)
+          - avgEyeOpenScore: \(core.avgEyeOpenScore)
+          - avgEyeClosedScore: \(core.avgEyeClosedScore)
+          - agBlinkFrequency: \(core.avgBlinkFrequency)
+          - avgCoreScore: \(core.avgCoreScore)
+          """)
+        }
+        
+        print("avgAuxDatas \(task.avgAuxDatas.count)개")
+        for (j, aux) in task.avgAuxDatas.enumerated() {
+          print("""
+          avgAuxDatas[\(j + 1)]
+          - avgBlinkScore: \(aux.avgBlinkScore)
+          - avgYawStabilityScore: \(aux.avgYawStabilityScore)
+          - avgMLSnoozeScore: \(aux.avgMlSnoozeScore)
+          - avgAuxScore: \(aux.avgAuxScore)
+          """)
+        }
+        print("==============================\n")
+      }
+    } catch {
+      print("TaskData 불러오기 실패: \(error)")
+    }
+  }
+}


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
자.. 내용이 길어요 여러분
1. ViewModel 너무 많은 책임을 지고 있는 것 같아서, 분리 했습니다.
✅ 밝기 조절 코드 View에서 하도록 리팩토링 했어요.
✅ ScoreManager 구현해서 계산은 ScoreManager에서 하도록 했어요. 대신 timer 관련한 계산은 ViewModel에서 따로 진행하도록 했습니당

2. 실시간 집중도 출력하도록 구현했어용

3. 밝기 조절 기능 수정했어요
✅ 자동 꺼짐 상태에서 화면 터치시 밝기 다시 밝아지고, 5초 후 다시 어두워지게 수정
✅ 밝기 어두워질 때 페이드 아웃 애니메이션 추가

4. SwiftData 모델 구현했고, Manager를 따로 구현했어용

5. SwiftData 저장 시, 분기 처리를 위해 컴플리션 핸들러로 처리했어요 + 분기처리용 enum 구현

❗️ 원래 이렇게 무자비하게 PR안날리는데 사정이 사정인지라 빠르게 개발 해봅시다 우리... 화이팅 !
## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->
1. 실시간 집중도 출력
![IMG_0616](https://github.com/user-attachments/assets/9e6da8c2-f7ab-4234-bebd-4f2e8782f28c)

2. 모델값 출력 로그 
<img width="722" height="472" alt="image" src="https://github.com/user-attachments/assets/c18a30c9-2acf-4127-9d6d-548a175e969a" />

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
1. SwiftDataManager에서 ModelContext 따로 주입하지 않아요 !! 
❓의존성 최소화 하려고요 ~ ModelContext는 뷰계층에서 주입되는 값인데, 이걸 ViewModel에 프로퍼티로 저장하면 ViewModel이 SwiftData 내부 구조에 직접 의존하게 되겠죠? 그래서 context를 필요로 할 때만 매개변수로 받아서 사용합니다 ~

2. 실시간 집중도는 나중에 UI입히면서 소수점 한자리 까지 표현할게요~

3. 컴플리션 핸들러 사용 이유?
 ❓ 비동기 작업의 결과를 기다렸다가 분기 처리 하려고요 !! 저장에 성공 했을 때, 저장에 실패했을 때, 10분 미만일 때를 분기처리 하기 위해 컴플리션 핸들러 사용했어요. 코드가 조금 복잡해서 나중에 리팩토링 한다면 컴바인으로 처리하면 간결해집니당 ~ 

4. 퀵헬프 주석 달아놨어요~ 한번 써봐요
<img width="632" height="516" alt="스크린샷 2025-07-24 오전 2 31 02" src="https://github.com/user-attachments/assets/38d2a364-d0f0-4d0e-a1b1-1c9fd33d5fd9" /> <br>
옵션 + 클릭하면 퀵헬프 떠요! 대신 퀵헬프 달려있는 것만 확인 가능!
## 🗑️ Resolved
<!-- 연결 할 이슈를 입력해주세요. ex) #1 -->
#28 
