### PR TITLE
[FIX] 밝기 문제 픽스

### DIFF
--- a/Pision/Pision/Source/Feature/Measure/ViewModel/MeasureViewModel.swift
+++ b/Pision/Pision/Source/Feature/Measure/ViewModel/MeasureViewModel.swift
@@ -88,11 +88,6 @@ final class MeasureViewModel: ObservableObject {
   init() {
     cameraManager = CameraManager(visionManager: visionManager)
     cameraManager.requestAndCheckPermissions()
-    if !isAutoBrightnessModeOn {
-      startAutoBrightnessMode()
-    } else {
-      cancelAutoBrightnessMode()
-    }
     
     visionManager.onSnoozeDetected = { [weak self] detected in
       guard detected else { return }
@@ -128,6 +123,7 @@ extension MeasureViewModel {
     timerState = .running
     startTimerLoop()
     cameraManager.startMeasuring()
+    startAutoBrightnessMode()
   }
   
   func timerPause() {
@@ -191,6 +187,8 @@ extension MeasureViewModel {
   
   private func startAutoBrightnessMode() {
     brightnessTimer?.cancel()
+    guard !isAutoBrightnessModeOn else { return }
+    
     let task = DispatchWorkItem {
       self.shouldDimScreen = true
     }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
뷰모델 생성 시 생성자에서 바로 자동 밝기 모드 진입하는 플로우여서 RecordView 들어오자마자 밝기가 줄어든 것 같습니다
진입점을 측정 시작 할 때로 수정했고, 토글 문제는 guard로 상태 체크 하도록 수정했습니다~
## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->

## 🗑️ Resolved
<!-- 연결 할 이슈를 입력해주세요. ex) #1 -->
#61 