### PR TITLE
[REFACTOR] 측정,가이드 세션 나누기, 타이머 매니저 구현

### DIFF
--- a/Pision/Pision/Source/Feature/Measure/View/MeasureRecordView.swift
+++ b/Pision/Pision/Source/Feature/Measure/View/MeasureRecordView.swift
@@ -67,15 +67,15 @@ extension MeasureRecordView {
       viewModel.cameraStop()
     }
     .onTapGesture {
-      viewModel.resetAutoDimTimer()
+      viewModel.resetAutoDim()
     }
   }
   
   private var brightnessOverlay: some View {
     Rectangle()
       .background(.B_00)
-      .opacity(viewModel.shouldDimScreen ? 0.85 : 0)
-      .animation(.easeInOut(duration: 0.3), value: viewModel.shouldDimScreen)
+      .opacity(viewModel.isShouldDimScreen ? 0.85 : 0)
+      .animation(.easeInOut(duration: 0.3), value: viewModel.isShouldDimScreen)
       .ignoresSafeArea()
   }
 }

--- a/Pision/Pision/Source/Feature/Measure/ViewModel/MeasureViewModel.swift
+++ b/Pision/Pision/Source/Feature/Measure/ViewModel/MeasureViewModel.swift
@@ -137,24 +137,28 @@ extension MeasureViewModel {
     timerManager.timerStart()
     timerState = .running
     timerManager.startAutoDim()
+    cameraManager.startMeasuring()
   }
   
   func timerPause() {
     guard timerState == .running else { return }
     timerManager.timerPause()
     timerState = .pause
+    cameraManager.stopMeasuring()
   }
   
   func timerResume() {
     guard timerState == .pause else { return }
     timerManager.timerResume()
     timerState = .running
+    cameraManager.startMeasuring()
   }
   
   func timerStop(context: ModelContext, completion: @escaping (SaveResult) -> Void) {
     timerManager.timerStop()
     timerState = .stopped
     timerManager.cancelAutoDim()
+    cameraManager.stopMeasuring()
   }
    
   func resetAutoDim() {
@@ -166,7 +170,7 @@ extension MeasureViewModel {
 // MARK: - Guiding
 extension MeasureViewModel {
   func guidingStart(screenWidth: CGFloat) {
-    cameraManager.startMeasuring()
+    cameraManager.startGuiding()
     checkYaw(screenWidth: screenWidth)
     
     Publishers.CombineLatest($isGuidingAngle, $isGuidingPose)
@@ -177,6 +181,7 @@ extension MeasureViewModel {
   }
   
   func guidingFinish() {
+    cameraManager.stopGuiding()
     isPresentedStartModal = false
     showCountdown = true
     //isNext = true

--- a/Pision/Pision/Source/Feature/Measure/ViewModel/MeasureViewModel.swift
+++ b/Pision/Pision/Source/Feature/Measure/ViewModel/MeasureViewModel.swift
@@ -15,7 +15,17 @@ final class MeasureViewModel: ObservableObject {
   // MARK: - Timer Var
   @Published private(set) var timerState: TimerState = .stopped
   @Published private(set) var secondsElapsed: Int = 0
-  private var timer: Timer?
+  @Published var isShouldDimScreen: Bool = false
+  @Published var isAutoBrightnessModeOn: Bool = false {
+    didSet {
+      if !isAutoBrightnessModeOn {
+        timerManager.startAutoDim()
+      } else {
+        timerManager.cancelAutoDim()
+        isShouldDimScreen = false
+      }
+    }
+  }
   
   var timeString: String {
     let hrs = secondsElapsed / 3600
@@ -23,21 +33,7 @@ final class MeasureViewModel: ObservableObject {
     let secs = secondsElapsed % 60
     return String(format: "%02d:%02d:%02d", hrs, mins, secs)
   }
-  
-  // MARK: - Brightness Var
-  @Published private(set) var shouldDimScreen: Bool = false
-  @Published var isAutoBrightnessModeOn: Bool = false {
-    didSet {
-      if !isAutoBrightnessModeOn {
-        startAutoBrightnessMode()
-      } else {
-        cancelAutoBrightnessMode()
-      }
-    }
-  }
-  
-  private var brightnessTimer: DispatchWorkItem?
-  
+
   // MARK: - Guiding Var
   @Published private(set) var isNext: Bool = false
   @Published private(set) var isGuidingAngle: Bool = false
@@ -78,6 +74,7 @@ final class MeasureViewModel: ObservableObject {
   private let visionManager = VisionManager()
   private let scoreManager = ScoreManager()
   private let swiftDataManager = SwiftDataManager()
+  private let timerManager = TimerManager()
   
   // Session
   var session: AVCaptureSession {
@@ -88,6 +85,8 @@ final class MeasureViewModel: ObservableObject {
   init() {
     cameraManager = CameraManager(visionManager: visionManager)
     cameraManager.requestAndCheckPermissions()
+    
+    bindTimer()
     
     visionManager.onSnoozeDetected = { [weak self] detected in
       guard detected else { return }
@@ -117,89 +116,50 @@ extension MeasureViewModel {
 
 // MARK: - Timer
 extension MeasureViewModel {
+  private func bindTimer() {
+    timerManager.onTick = { [weak self] sec in
+      guard let self = self else { return }
+      DispatchQueue.main.async {
+        self.secondsElapsed = sec
+      }
+    }
+    
+    timerManager.onAutoDim = { [weak self] in
+      guard let self = self else { return }
+      DispatchQueue.main.async {
+        print("호출")
+        self.isShouldDimScreen = true
+      }
+    }
+  }
+  
   func timerStart() {
-    secondsElapsed = 0
-    focusTime = 0
+    timerManager.timerStart()
     timerState = .running
-    startTimerLoop()
-    cameraManager.startMeasuring()
-    startAutoBrightnessMode()
+    timerManager.startAutoDim()
   }
   
   func timerPause() {
     guard timerState == .running else { return }
-    timer?.invalidate()
+    timerManager.timerPause()
     timerState = .pause
-    cameraManager.stopMeasuring()
   }
   
   func timerResume() {
     guard timerState == .pause else { return }
+    timerManager.timerResume()
     timerState = .running
-    startTimerLoop()
-    cameraManager.startMeasuring()
   }
   
   func timerStop(context: ModelContext, completion: @escaping (SaveResult) -> Void) {
-    timer?.invalidate()
-    timer = nil
+    timerManager.timerStop()
     timerState = .stopped
-    cameraManager.stopMeasuring()
-    cancelAutoBrightnessMode()
-    
-    saveRemainingAverage()
-    
-    saveTaskDataAndSaveToSwiftData(context: context, completion: completion)
+    timerManager.cancelAutoDim()
   }
-  
-  private func startTimerLoop() {
-    timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true) { [weak self] _ in
-      guard let self = self else { return }
-      self.secondsElapsed += 1
-      
-      if self.secondsElapsed % 30 == 0 {
-        self.calculateScores()
-      }
-      
-      if self.secondsElapsed % 600 == 0 {
-        DispatchQueue.main.asyncAfter(deadline: .now() + 2) {
-          self.save10MinuteAverage()
-        }
-      }
-    }
-  }
-}
-
-// MARK: - Brightness
-extension MeasureViewModel {
-  func resetAutoDimTimer() {
-    brightnessTimer?.cancel()
-    
-    let task = DispatchWorkItem { [weak self] in
-      self?.shouldDimScreen = true
-    }
-    
-    brightnessTimer = task
-    DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: task)
-    
-    shouldDimScreen = false
-  }
-  
-  private func startAutoBrightnessMode() {
-    brightnessTimer?.cancel()
-    guard !isAutoBrightnessModeOn else { return }
-    
-    let task = DispatchWorkItem {
-      self.shouldDimScreen = true
-    }
-    brightnessTimer = task
-    DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: task)
-  }
-  
-  private func cancelAutoBrightnessMode() {
-    brightnessTimer?.cancel()
-    brightnessTimer = nil
-    shouldDimScreen = false
+   
+  func resetAutoDim() {
+    timerManager.resetAutoDim()
+    isShouldDimScreen = false
   }
 }
 

--- a/Pision/Pision/Source/Utilities/Manager/TimerManager.swift
+++ b/Pision/Pision/Source/Utilities/Manager/TimerManager.swift
@@ -1,0 +1,70 @@
+//
+//  TimerManager.swift
+//  Pision
+//
+//  Created by 여성일 on 7/28/25.
+//
+
+import Foundation
+
+// MARK: - General
+final class TimerManager {
+  // Internal
+  private var timer: Timer?
+  private var autoDimWorkItem: DispatchWorkItem?
+  private(set) var secondsElapsed:Int = 0
+  
+  // CallBack
+  var onTick: ((Int) -> Void)?
+  var onAutoDim: (() -> Void)?
+}
+
+// MARK: - Method
+extension TimerManager {
+  func timerStart() {
+    secondsElapsed = 0
+    startTimerLoop()
+  }
+  
+  func timerPause() {
+    timer?.invalidate()
+    timer = nil
+  }
+  
+  func timerResume() {
+    guard timer == nil else { return }
+    startTimerLoop()
+  }
+  
+  func timerStop() {
+    timer?.invalidate()
+    timer = nil
+    cancelAutoDim()
+  }
+    
+  func startTimerLoop() {
+    timer = Timer.scheduledTimer(withTimeInterval: 1, repeats: true, block: { [weak self] _ in
+      guard let self = self else { return }
+      self.secondsElapsed += 1
+      onTick?(self.secondsElapsed)
+    })
+  }
+  
+  func startAutoDim() {
+    cancelAutoDim()
+    let work = DispatchWorkItem {
+      self.onAutoDim?()
+    }
+    autoDimWorkItem = work
+    DispatchQueue.main.asyncAfter(deadline: .now() + 5, execute: work)
+  }
+  
+  func cancelAutoDim() {
+    autoDimWorkItem?.cancel()
+    autoDimWorkItem = nil
+  }
+  
+  func resetAutoDim() {
+    startAutoDim()
+  }
+}


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
아직 개발해야할 부분이 남아서 남은 리팩토링은 개발 다 하고 마저 하겠습니다

1. 측정, 가이드 세션 나누기
가이딩 세션과 측정 세션이 동일한 세션이어서 가이딩 할때 필요없는 메소드가 동작하는 경우가 있어서 수정했습니다.
2. 타이머 매니저
일단 뷰모델에서 너무 많은 책임을 지고 있어서 타이머 매니저 추가로 구현했습니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->

## 🗑️ Resolved
<!-- 연결 할 이슈를 입력해주세요. ex) #1 -->
#63 
